### PR TITLE
[IFB-860] fix: dockerfile 버그

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ ARG SENTRY_AUTH_TOKEN
 ENV SENTRY_AUTH_TOKEN=$SENTRY_AUTH_TOKEN
 
 # Build the application using Gradle
+RUN chmod +x gradlew
 RUN ./gradlew clean build --no-daemon --stacktrace --info -Dorg.gradle.vfs.watch=false
 
 # Uncomment if using Maven instead


### PR DESCRIPTION
## Issue
GitHub Actions에서 아래 에러 발생

```
------
Dockerfile:11
--------------------
   9 |     
  10 |     # Build the application using Gradle
  11 | >>> RUN ./gradlew clean build --no-daemon --stacktrace --info -Dorg.gradle.vfs.watch=false
  12 |     
  13 |     # Uncomment if using Maven instead
--------------------
ERROR: failed to solve: process "/bin/sh -c ./gradlew clean build --no-daemon --stacktrace --info -Dorg.gradle.vfs.watch=false" did not complete successfully: exit code: 1
Error: Process completed with exit code 1.

```
## Solution
dockerfile에 해당 라인 추가
`RUN chmod +x gradlew`